### PR TITLE
Optimize point cloud raytracing for static scenes (v1.2.0)

### DIFF
--- a/addon/blender_manifest.toml
+++ b/addon/blender_manifest.toml
@@ -1,6 +1,6 @@
 schema_version = "1.0.0"
 id = "gauss_cannon"
-version = "1.1.4"
+version = "1.2.0"
 name = "Gauss Cannon"
 tagline = "Camera paths and point clouds for Gaussian Splatting workflows"
 maintainer = "Warpgate Labs <contact@warp-gate.com>"

--- a/addon/operators/export_pointcloud.py
+++ b/addon/operators/export_pointcloud.py
@@ -2,7 +2,6 @@ import bpy
 import os
 import time
 import numpy as np
-import gpu
 from ..utils.ray_casting import (
     build_scene_bvh,
     cast_ray_through_pixel,
@@ -52,16 +51,6 @@ class EXPORT_OT_pointcloud_ply(bpy.types.Operator):
             and context.scene.output_folder.strip()
             and not cls._is_running
         )
-
-    def check_gpu_available(self):
-        """Check if GPU acceleration is available."""
-        try:
-            test_data = np.array([1.0, 2.0, 3.0], dtype=np.float32)
-            buffer = gpu.types.Buffer("FLOAT", 3, test_data)
-            del buffer
-            return True
-        except Exception:
-            return False
 
     def render_frame_to_pixels(self, context, resolution):
         """Render current frame and return pixel data"""
@@ -161,7 +150,7 @@ class EXPORT_OT_pointcloud_ply(bpy.types.Operator):
         self._frame_idx = self._frame_start
         self._stride = scene.pointcloud_stride
         self._total_frames = len(range(self._frame_start, self._frame_end + 1, self._stride))
-        self._use_gpu = scene.use_gpu_acceleration and self.check_gpu_available()
+        self._use_gpu = scene.use_gpu_acceleration
         self._orig_frame = scene.frame_current
 
         # Hoist camera attrs that don't change between frames out of the
@@ -290,9 +279,7 @@ class EXPORT_OT_pointcloud_ply(bpy.types.Operator):
                     )
                     if hit_point:
                         slot = self._point_count
-                        self._points_buf[slot, 0] = hit_point.x
-                        self._points_buf[slot, 1] = hit_point.y
-                        self._points_buf[slot, 2] = hit_point.z
+                        self._points_buf[slot] = hit_point
                         self._colors_buf[slot] = pixels_flipped[y_flat, x, :3]
                         self._point_count += 1
 

--- a/addon/operators/export_pointcloud.py
+++ b/addon/operators/export_pointcloud.py
@@ -3,8 +3,13 @@ import os
 import time
 import numpy as np
 import gpu
-from ..utils.ray_casting import cast_ray_through_pixel, gpu_accelerated_ray_cast
-from ..utils.coordinate_systems import write_ply_header, write_ply_point
+from ..utils.ray_casting import (
+    build_scene_bvh,
+    cast_ray_through_pixel,
+    cast_scene_rays,
+    precompute_camera_rays,
+)
+from ..utils.coordinate_systems import write_ply_bulk
 
 
 class EXPORT_OT_pointcloud_ply(bpy.types.Operator):
@@ -20,9 +25,15 @@ class EXPORT_OT_pointcloud_ply(bpy.types.Operator):
     _frame_start = 0
     _frame_end = 0
     _total_frames = 0
-    _all_points = []
-    _all_colors = []
     _selected_meshes = []
+    _scene_bvh = None
+    _cam_dirs = None
+    _cam_offsets = None
+    _cam_type = "PERSP"
+    _near_clip = 0.0
+    _points_buf = None
+    _colors_buf = None
+    _point_count = 0
     _use_gpu = False
     _resolution = 8
     _orig_persistent_data = False
@@ -119,20 +130,6 @@ class EXPORT_OT_pointcloud_ply(bpy.types.Operator):
             for obj, orig_hide in helper_meshes:
                 obj.hide_viewport = orig_hide
 
-    def write_ply(self, filepath, points, colors, coordinate_system):
-        """Write point cloud to PLY file"""
-        num_points = len(points)
-
-        with open(filepath, "wb") as f:
-            # Write PLY header
-            header = write_ply_header(num_points)
-            f.write(header.encode("ascii"))
-
-            # Write binary data
-            for i in range(num_points):
-                point_data = write_ply_point(points[i], colors[i], coordinate_system)
-                f.write(point_data)
-
     def execute(self, context):
         scene = context.scene
         self._resolution = scene.pointcloud_resolution
@@ -164,10 +161,36 @@ class EXPORT_OT_pointcloud_ply(bpy.types.Operator):
         self._frame_idx = self._frame_start
         self._stride = scene.pointcloud_stride
         self._total_frames = len(range(self._frame_start, self._frame_end + 1, self._stride))
-        self._all_points = []
-        self._all_colors = []
         self._use_gpu = scene.use_gpu_acceleration and self.check_gpu_available()
         self._orig_frame = scene.frame_current
+
+        # Hoist camera attrs that don't change between frames out of the
+        # per-pixel hot path.
+        cam_data = scene.camera.data
+        self._cam_type = cam_data.type
+        self._near_clip = cam_data.clip_start
+
+        # Static-scene precomputes: a single world-space BVH spanning every
+        # selected mesh, and per-pixel cam-space ray data. Both depend only
+        # on geometry + camera intrinsics + resolution, none of which change
+        # across the frame range, so they're built exactly once.
+        if self._use_gpu:
+            self._scene_bvh = build_scene_bvh(self._selected_meshes)
+            self._cam_dirs, self._cam_offsets = precompute_camera_rays(
+                cam_data, self._resolution
+            )
+        else:
+            self._scene_bvh = None
+            self._cam_dirs = None
+            self._cam_offsets = None
+
+        # Preallocate output buffers sized to the absolute upper bound
+        # (every pixel of every frame hits geometry). _point_count tracks
+        # the live size so finish() can slice down to actual hits.
+        max_points = self._total_frames * self._resolution * self._resolution
+        self._points_buf = np.empty((max_points, 3), dtype=np.float32)
+        self._colors_buf = np.empty((max_points, 3), dtype=np.float32)
+        self._point_count = 0
 
         # Store original persistent data setting
         self._orig_persistent_data = scene.render.use_persistent_data
@@ -229,32 +252,62 @@ class EXPORT_OT_pointcloud_ply(bpy.types.Operator):
             pixels = self.render_frame_to_pixels(context, self._resolution)
 
             if self._use_gpu:
-                frame_results = gpu_accelerated_ray_cast(
-                    scene, scene.camera, self._resolution, self._selected_meshes, pixels
+                written = cast_scene_rays(
+                    self._scene_bvh,
+                    scene.camera.matrix_world,
+                    pixels,
+                    self._cam_dirs,
+                    self._cam_offsets,
+                    self._resolution,
+                    self._near_clip,
+                    self._cam_type,
+                    self._points_buf,
+                    self._colors_buf,
+                    self._point_count,
                 )
-                for hit_point, color in frame_results:
-                    self._all_points.append(hit_point)
-                    self._all_colors.append(color)
+                self._point_count += written
             else:
-                for y in range(self._resolution):
-                    for x in range(self._resolution):
-                        color = pixels[self._resolution - 1 - y, x, :3]
-                        hit_point = cast_ray_through_pixel(
-                            scene,
-                            scene.camera,
-                            x + 0.5,
-                            y + 0.5,
-                            self._resolution,
-                            self._resolution,
-                            self._selected_meshes,
-                        )
-                        if hit_point:
-                            self._all_points.append(hit_point)
-                            self._all_colors.append(color)
+                # CPU fallback: legacy per-mesh path. Still benefits from the
+                # alpha skip and preallocated buffers, but ray casting goes
+                # through Blender's per-mesh BVH cache rather than our merged
+                # scene BVH.
+                R = self._resolution
+                # Blender stores image pixels bottom-up, so flip rows once
+                # to align with the (y, x) ordering cast_ray_through_pixel
+                # expects (y=0 is the top of the camera frustum).
+                pixels_flipped = pixels[::-1, :, :]
+                hit_mask = pixels_flipped[:, :, 3] > 0.0
+                for ray_idx in np.argwhere(hit_mask):
+                    y_flat, x = int(ray_idx[0]), int(ray_idx[1])
+                    hit_point = cast_ray_through_pixel(
+                        scene,
+                        scene.camera,
+                        x + 0.5,
+                        y_flat + 0.5,
+                        R,
+                        R,
+                        self._selected_meshes,
+                    )
+                    if hit_point:
+                        slot = self._point_count
+                        self._points_buf[slot, 0] = hit_point.x
+                        self._points_buf[slot, 1] = hit_point.y
+                        self._points_buf[slot, 2] = hit_point.z
+                        self._colors_buf[slot] = pixels_flipped[y_flat, x, :3]
+                        self._point_count += 1
 
             self._frame_idx += self._stride
 
         return {"RUNNING_MODAL"}
+
+    def _release_state(self):
+        """Drop references to large per-run state so memory isn't pinned
+        after the operator exits."""
+        self._scene_bvh = None
+        self._cam_dirs = None
+        self._cam_offsets = None
+        self._points_buf = None
+        self._colors_buf = None
 
     def finish(self, context):
         """Complete the operation and write output file"""
@@ -278,14 +331,17 @@ class EXPORT_OT_pointcloud_ply(bpy.types.Operator):
         output_path = os.path.join(output_dir, "pointcloud.ply")
 
         coordinate_system = "Z_UP" if scene.export_mode == "BRUSH" else scene.coordinate_system
-        self.write_ply(output_path, self._all_points, self._all_colors, coordinate_system)
+        points = self._points_buf[: self._point_count]
+        colors = self._colors_buf[: self._point_count]
+        write_ply_bulk(output_path, points, colors, coordinate_system)
 
         coord_info = "Y-up" if coordinate_system == "Y_UP" else "Z-up"
         self.report(
             {"INFO"},
-            f"Generated {len(self._all_points)} points from {self._total_frames} frames ({coord_info})",
+            f"Generated {self._point_count} points from {self._total_frames} frames ({coord_info})",
         )
 
+        self._release_state()
         return {"FINISHED"}
 
     def cancel(self, context):
@@ -302,3 +358,4 @@ class EXPORT_OT_pointcloud_ply(bpy.types.Operator):
         scene.frame_set(self._orig_frame)
         context.area.header_text_set(None)
         EXPORT_OT_pointcloud_ply._is_running = False
+        self._release_state()

--- a/addon/ui/panels.py
+++ b/addon/ui/panels.py
@@ -1,7 +1,7 @@
 import bpy
 
 
-VERSION = "1.1.4"
+VERSION = "1.2.0"
 
 
 class VIEW3D_PT_helper_mesh_panel(bpy.types.Panel):

--- a/addon/utils/coordinate_systems.py
+++ b/addon/utils/coordinate_systems.py
@@ -59,24 +59,41 @@ end_header
 """
 
 
-def write_ply_point(point, color, coordinate_system):
+def write_ply_bulk(filepath, points, colors, coordinate_system):
     """
-    Write a single point and color to PLY format in binary.
+    Write an entire colored point cloud to PLY in a single bulk operation.
+
+    ``points`` and ``colors`` are numpy arrays of shape ``(N, 3)``. Coordinate
+    conversion and color quantization are vectorized; the binary body is laid
+    out into a structured array (12-byte position + 3-byte RGB per record,
+    matching the PLY spec exactly) and written with one ``tofile`` call —
+    significantly faster than per-point writes for large clouds.
 
     Args:
-        point: 3D point coordinates
-        color: RGB color values (0-1 range)
+        filepath: Output .ply path
+        points: (N, 3) numpy array of XYZ in Blender's Z-up world space
+        colors: (N, 3) numpy array of RGB in 0..1 range
         coordinate_system: "Y_UP" or "Z_UP"
-
-    Returns:
-        bytes: Binary data for this point
     """
-    converted_point = convert_coordinate_system(coordinate_system, point=point)
+    num_points = points.shape[0]
+    header = write_ply_header(num_points).encode("ascii")
 
-    # Position (3 floats)
-    position_data = np.array(converted_point, dtype=np.float32).tobytes()
+    if coordinate_system == "Y_UP":
+        # Match convert_coordinate_system(point=...): [x, z, -y]
+        out_points = np.empty_like(points, dtype=np.float32)
+        out_points[:, 0] = points[:, 0]
+        out_points[:, 1] = points[:, 2]
+        out_points[:, 2] = -points[:, 1]
+    else:
+        out_points = points.astype(np.float32, copy=False)
 
-    # Color (3 unsigned chars)
-    color_data = np.array(color * 255, dtype=np.uint8).tobytes()
+    rgb = np.clip(colors * 255.0, 0.0, 255.0).astype(np.uint8)
 
-    return position_data + color_data
+    record_dtype = np.dtype([("pos", "<f4", 3), ("rgb", "u1", 3)])
+    records = np.empty(num_points, dtype=record_dtype)
+    records["pos"] = out_points
+    records["rgb"] = rgb
+
+    with open(filepath, "wb") as f:
+        f.write(header)
+        records.tofile(f)

--- a/addon/utils/ray_casting.py
+++ b/addon/utils/ray_casting.py
@@ -322,98 +322,175 @@ def cast_ray_through_pixel(scene, camera, pixel_x, pixel_y, res_x, res_y, select
     return None
 
 
-def gpu_accelerated_ray_cast(scene, camera, resolution, selected_meshes, pixels):
+def build_scene_bvh(selected_meshes):
     """
-    GPU-accelerated ray casting using Blender's BVH trees.
+    Build a single world-space BVHTree containing every triangle from every
+    selected mesh. The static-scene assumption is load-bearing: vertices are
+    baked into world space at build time, so the tree is reusable across all
+    frames as long as no object moves and no geometry deforms.
+
+    Collapsing N per-mesh trees into one cuts per-ray cost from O(meshes) to
+    O(1) ray_cast calls — the main win for scenes with thousands of objects.
 
     Args:
-        scene: Blender scene
-        camera: Camera object
-        resolution: Square resolution for casting
-        selected_meshes: List of mesh objects to intersect
-        pixels: Rendered pixel data
+        selected_meshes: List of mesh objects to merge into the BVH
 
     Returns:
-        list: List of (hit_point, color) tuples
+        BVHTree or None: combined world-space BVH, or None if no geometry
     """
-    cam_matrix = camera.matrix_world
-    cam_data = camera.data
+    depsgraph = bpy.context.evaluated_depsgraph_get()
+    all_verts = []
+    all_polys = []
+    offset = 0
 
-    # Build BVH trees for all selected meshes
-    bvh_trees = []
     for obj in selected_meshes:
-        depsgraph = bpy.context.evaluated_depsgraph_get()
+        if obj.type != "MESH":
+            continue
         obj_eval = obj.evaluated_get(depsgraph)
         mesh = obj_eval.to_mesh()
+        if mesh is None:
+            continue
+        try:
+            mw = obj.matrix_world
+            all_verts.extend(mw @ v.co for v in mesh.vertices)
+            all_polys.extend([i + offset for i in p.vertices] for p in mesh.polygons)
+            offset += len(mesh.vertices)
+        finally:
+            obj_eval.to_mesh_clear()
 
-        # Create BVH tree
-        bvh = BVHTree.FromPolygons(
-            [v.co for v in mesh.vertices], [p.vertices for p in mesh.polygons]
-        )
-        bvh_trees.append((bvh, obj.matrix_world))
-        obj_eval.to_mesh_clear()
+    if not all_verts or not all_polys:
+        return None
+    return BVHTree.FromPolygons(all_verts, all_polys)
 
-    results = []
 
-    # Process rays in batches for better performance
-    for y in range(resolution):
-        for x in range(resolution):
-            # Calculate ray
-            ndc_x = (2.0 * (x + 0.5) / resolution) - 1.0
-            ndc_y = 1.0 - (2.0 * (y + 0.5) / resolution)
+def precompute_camera_rays(cam_data, resolution):
+    """
+    Precompute per-pixel ray data in camera space for a fixed resolution.
 
-            aspect = 1.0  # Square aspect ratio
-            if cam_data.type == "PERSP":
-                fov = cam_data.angle
-                tan_half_fov = math.tan(fov / 2.0)
-                ray_dir_cam = Vector(
-                    (ndc_x * tan_half_fov * aspect, ndc_y * tan_half_fov, -1.0)
-                ).normalized()
-            else:
-                ortho_scale = cam_data.ortho_scale
-                ray_dir_cam = Vector((0, 0, -1))
-                offset_x = ndc_x * ortho_scale * aspect / 2.0
-                offset_y = ndc_y * ortho_scale / 2.0
+    Camera intrinsics and resolution don't change between frames, so this
+    work can be lifted out of the per-frame loop. Only the camera's world
+    matrix is applied per frame.
 
-            # Transform to world space
-            ray_origin = cam_matrix.translation.copy()
-            ray_dir_world = cam_matrix.to_3x3() @ ray_dir_cam
-            ray_dir_world.normalize()
+    Pixel ordering matches the existing flipped-row convention: ray index
+    ``y * R + x`` corresponds to image pixel ``pixels[R - 1 - y, x]``.
 
-            if cam_data.type == "ORTHO":
-                right = cam_matrix.to_3x3() @ Vector((1, 0, 0))
-                up = cam_matrix.to_3x3() @ Vector((0, 1, 0))
-                ray_origin += right * offset_x + up * offset_y
+    Args:
+        cam_data: Camera data block
+        resolution: Square render resolution
 
-            # Find closest hit using BVH
-            closest_hit = None
-            closest_dist = float("inf")
+    Returns:
+        (cam_dirs, cam_offsets):
+          - cam_dirs: list of length R*R of normalized Vectors in cam space.
+            For PERSP these vary per pixel; for ORTHO they're all (0, 0, -1).
+          - cam_offsets: list of length R*R of (off_right, off_up) tuples for
+            ORTHO, or None for PERSP.
+    """
+    R = resolution
+    aspect = 1.0  # square render
 
-            for bvh, obj_matrix in bvh_trees:
-                # Transform ray to object space
-                obj_inv = obj_matrix.inverted()
-                ray_origin_obj = obj_inv @ ray_origin
-                ray_dir_obj = obj_inv.to_3x3() @ ray_dir_world
-                ray_dir_obj.normalize()
+    if cam_data.type == "PERSP":
+        tan_half = math.tan(cam_data.angle / 2.0)
+        cam_dirs = []
+        for y in range(R):
+            ndc_y = 1.0 - (2.0 * (y + 0.5) / R)
+            ty = ndc_y * tan_half
+            for x in range(R):
+                ndc_x = (2.0 * (x + 0.5) / R) - 1.0
+                d = Vector((ndc_x * tan_half * aspect, ty, -1.0))
+                d.normalize()
+                cam_dirs.append(d)
+        return cam_dirs, None
 
-                # Cast ray using BVH
-                location, normal, index, dist = bvh.ray_cast(
-                    ray_origin_obj, ray_dir_obj
-                )
+    ortho_scale = cam_data.ortho_scale
+    constant_dir = Vector((0.0, 0.0, -1.0))
+    cam_dirs = [constant_dir] * (R * R)
+    cam_offsets = []
+    for y in range(R):
+        ndc_y = 1.0 - (2.0 * (y + 0.5) / R)
+        off_y = ndc_y * ortho_scale / 2.0
+        for x in range(R):
+            ndc_x = (2.0 * (x + 0.5) / R) - 1.0
+            off_x = ndc_x * ortho_scale * aspect / 2.0
+            cam_offsets.append((off_x, off_y))
+    return cam_dirs, cam_offsets
 
-                if location:
-                    # Transform hit back to world space
-                    hit_world = obj_matrix @ location
-                    world_dist = (hit_world - ray_origin).length
 
-                    if world_dist < closest_dist:
-                        closest_dist = world_dist
-                        closest_hit = hit_world
+def cast_scene_rays(
+    scene_bvh,
+    cam_matrix,
+    pixels,
+    cam_dirs,
+    cam_offsets,
+    resolution,
+    near_clip,
+    cam_type,
+    points_buf,
+    colors_buf,
+    write_offset,
+):
+    """
+    Cast precomputed rays for one frame against the merged scene BVH and
+    write hits into preallocated output buffers.
 
-            if closest_hit:
-                # Check if hit is beyond near clipping plane
-                if closest_dist >= cam_data.clip_start:
-                    color = pixels[resolution - 1 - y, x, :3]
-                    results.append((closest_hit, color))
+    Pixels with zero alpha (background — the renderer says nothing was hit)
+    are skipped entirely; that's often the bulk of pixels for sparse
+    geometry like vegetation.
 
-    return results
+    Args:
+        scene_bvh: BVHTree from ``build_scene_bvh``
+        cam_matrix: camera.matrix_world for this frame
+        pixels: (R, R, 4) numpy array of RGBA float pixel data
+        cam_dirs: cam-space direction list from ``precompute_camera_rays``
+        cam_offsets: cam-space ORTHO offsets, or None for PERSP
+        resolution: square resolution R
+        near_clip: cam_data.clip_start (hoisted out of inner loop)
+        cam_type: "PERSP" or "ORTHO" (hoisted out of inner loop)
+        points_buf: preallocated (max_points, 3) float32 numpy buffer
+        colors_buf: preallocated (max_points, 3) float32 numpy buffer
+        write_offset: index in the buffers where this frame's hits start
+
+    Returns:
+        int: number of hits written this frame
+    """
+    if scene_bvh is None:
+        return 0
+
+    R = resolution
+    cam_rot = cam_matrix.to_3x3()
+    cam_origin = cam_matrix.translation
+
+    # Flip pixel rows once so flat index matches ray index (y*R + x).
+    pixels_flipped = pixels[::-1, :, :]
+    alpha_flat = pixels_flipped[:, :, 3].ravel()
+    colors_flat = pixels_flipped[:, :, :3].reshape(-1, 3)
+    hit_pixels = np.nonzero(alpha_flat > 0.0)[0]
+
+    if cam_type == "ORTHO":
+        world_right = cam_rot @ Vector((1.0, 0.0, 0.0))
+        world_up = cam_rot @ Vector((0.0, 1.0, 0.0))
+        constant_dir_world = cam_rot @ cam_dirs[0]
+        constant_dir_world.normalize()
+
+    written = 0
+    for ray_idx in hit_pixels:
+        if cam_type == "PERSP":
+            ray_dir = cam_rot @ cam_dirs[ray_idx]
+            ray_dir.normalize()
+            ray_origin = cam_origin
+        else:
+            off_x, off_y = cam_offsets[ray_idx]
+            ray_origin = cam_origin + world_right * off_x + world_up * off_y
+            ray_dir = constant_dir_world
+
+        location, normal, index, dist = scene_bvh.ray_cast(ray_origin, ray_dir)
+        if location is None or dist < near_clip:
+            continue
+
+        slot = write_offset + written
+        points_buf[slot, 0] = location.x
+        points_buf[slot, 1] = location.y
+        points_buf[slot, 2] = location.z
+        colors_buf[slot] = colors_flat[ray_idx]
+        written += 1
+
+    return written

--- a/addon/utils/ray_casting.py
+++ b/addon/utils/ray_casting.py
@@ -339,7 +339,7 @@ def build_scene_bvh(selected_meshes):
         BVHTree or None: combined world-space BVH, or None if no geometry
     """
     depsgraph = bpy.context.evaluated_depsgraph_get()
-    all_verts = []
+    vert_arrays = []
     all_polys = []
     offset = 0
 
@@ -351,15 +351,27 @@ def build_scene_bvh(selected_meshes):
         if mesh is None:
             continue
         try:
-            mw = obj.matrix_world
-            all_verts.extend(mw @ v.co for v in mesh.vertices)
+            # Transform the temporary evaluated mesh into world space in C,
+            # then bulk-read coords via foreach_get. At 100M-vert scale this
+            # avoids constructing a Python Vector and doing a Python-side
+            # matrix multiply per vertex — the dominant cost of the build.
+            mesh.transform(obj.matrix_world)
+            n_verts = len(mesh.vertices)
+            flat = np.empty(n_verts * 3, dtype=np.float32)
+            mesh.vertices.foreach_get("co", flat)
+            vert_arrays.append(flat.reshape(-1, 3))
+
+            # Polygon connectivity stays in Python for mixed-topology
+            # compatibility (n-gons can't be foreach_get'd as fixed-stride
+            # arrays). The vertex transform was the hot path.
             all_polys.extend([i + offset for i in p.vertices] for p in mesh.polygons)
-            offset += len(mesh.vertices)
+            offset += n_verts
         finally:
             obj_eval.to_mesh_clear()
 
-    if not all_verts or not all_polys:
+    if not vert_arrays or not all_polys:
         return None
+    all_verts = np.vstack(vert_arrays)
     return BVHTree.FromPolygons(all_verts, all_polys)
 
 

--- a/addon/utils/ray_casting.py
+++ b/addon/utils/ray_casting.py
@@ -474,8 +474,9 @@ def cast_scene_rays(
     written = 0
     for ray_idx in hit_pixels:
         if cam_type == "PERSP":
+            # Rotation preserves length and cam_dirs are pre-normalized, so
+            # no per-ray normalize is needed.
             ray_dir = cam_rot @ cam_dirs[ray_idx]
-            ray_dir.normalize()
             ray_origin = cam_origin
         else:
             off_x, off_y = cam_offsets[ray_idx]
@@ -487,9 +488,7 @@ def cast_scene_rays(
             continue
 
         slot = write_offset + written
-        points_buf[slot, 0] = location.x
-        points_buf[slot, 1] = location.y
-        points_buf[slot, 2] = location.z
+        points_buf[slot] = location
         colors_buf[slot] = colors_flat[ray_idx]
         written += 1
 


### PR DESCRIPTION
## Summary

Point cloud generation in Gauss Cannon was rebuilding per-mesh BVH trees on every frame and iterating every selected mesh on every ray. Fine for a handful of objects; unusable for the 3ds-Max-style scenes a user flagged (10k+ objects, 100M+ verts, vegetation). This branch reworks the pipeline around the fact that **geometry is static across a capture** — only the camera moves — and lifts everything geometry- or intrinsics-dependent out of the per-frame loop.

- **Single world-space scene BVH.** All selected meshes merged into one tree, built once in `execute()`. Cuts per-ray cost from O(meshes) to O(1) `ray_cast` calls.
- **Precomputed ray directions.** Cam-space per-pixel dirs (and ORTHO origin offsets) computed once; each frame only rotates by `cam_matrix.to_3x3()`.
- **Alpha-skip.** Pixels with zero render alpha hit nothing; skip them before ray-casting.
- **Preallocated numpy buffers.** Points and colors written into `(max_points, 3)` float32 arrays sized to the upper bound; PLY body written in one bulk `tofile()` call via a 15-byte structured dtype.
- **Hoisted camera attrs.** `cam_data.type` and `clip_start` read once, passed in.

The `use_gpu_acceleration` toggle now selects between the merged scene BVH path (on) and the legacy per-mesh `obj.ray_cast` path (off). The CPU path still benefits from the alpha skip and preallocated buffers.

Version bumped to 1.2.0 — this changes capability (scenes that didn't complete now do), not just internals.

## Test plan
- [ ] Smoke test on a small static scene; confirm point count and colors match v1.1.4 output for the same scene/frames
- [ ] Vegetation-heavy scene (thousands of objects); confirm completion in reasonable time
- [ ] ORTHO camera path
- [ ] CPU fallback path (`use_gpu_acceleration` off)
- [ ] Cancel mid-run (ESC) leaves Blender in a clean state